### PR TITLE
Override Notification Url doesn't work

### DIFF
--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -32,7 +32,7 @@ class HttpClient{
       reqQueryParam = secondParam;
     }
 
-    return new Promise(function(resolve,reject){
+    return new Promise((resolve,reject) => {
       // Reject if param is not JSON
       if(typeof reqBodyPayload === 'string' || reqBodyPayload instanceof String){
         try{
@@ -50,7 +50,7 @@ class HttpClient{
         }
       }
 
-      let response = axios({
+      let response = this.http_client({
         method: httpMethod,
         headers: headers,
         url: requestUrl,


### PR DESCRIPTION
**Module Version**: midtrans-client@1.2.2

**What's the problem?**

I can not override the notification URL with the module this way: 
```
MidtransClient.httpClient.http_client.defaults.headers.common['X-Override-Notification'] = 'https://example.com/notifications'
```
The notification is always sent to the URL described on the Midtrans dashboard (SETTINGS > CONFIGURATION)

**Expected Condition** 

If 'X-Override-Notification' is used, then the notification should be sent to the new URL.

**Possible Causes**

Method request on the Class HttpClient always uses Axios instead of using http_client from the constructor. So when I add headers with  `MidtransClient.httpClient.http_client.defaults.headers.common['X-Override-Notification']`, It does not give any effect.

**Solution**

Use http_client from the constructor.
